### PR TITLE
Added an optional patch for Pet.cpp for better pet handling

### DIFF
--- a/Pet.cpp.beastmaster.patch
+++ b/Pet.cpp.beastmaster.patch
@@ -1,0 +1,28 @@
+--- Pet.cpp	2018-05-11 00:49:59.129230836 +0200
++++ Pet.cpp.beastmaster	2018-05-11 11:43:30.088735926 +0200
+@@ -673,6 +673,7 @@
+     PetType petType = MAX_PET_TYPE;
+     if (IsPet() && m_owner->GetTypeId() == TYPEID_PLAYER)
+     {
++        /* use another check due to mod-npcbeastmaster
+         if (m_owner->getClass() == CLASS_WARLOCK ||
+             m_owner->getClass() == CLASS_SHAMAN ||          // Fire Elemental
+             m_owner->getClass() == CLASS_DEATH_KNIGHT ||    // Risen Ghoul
+@@ -685,6 +686,17 @@
+         }
+         else
+             sLog->outError("Unknown type pet %u is summoned by player class %u", GetEntry(), m_owner->getClass());
++        */
++        // better pet handling for mod-npcbeastmaster
++        if (cinfo->IsTameable(true))
++        {
++            petType = HUNTER_PET;
++            m_unitTypeMask |= UNIT_MASK_HUNTER_PET;
++        }
++        else
++        {
++            petType = SUMMON_PET;
++        }
+     }
+ 
+     uint32 creature_ID = (petType == HUNTER_PET) ? 1 : cinfo->Entry;

--- a/conf/npc_beastmaster.conf.dist
+++ b/conf/npc_beastmaster.conf.dist
@@ -9,6 +9,11 @@
 BeastMaster.Announce = 1
 
 # Enable only for the Hunter class?
+# (If this option is set to 0 you can also apply the following patch for better pet handling:
+# patch -l src/server/game/Entities/Pet/Pet.cpp <modules/mod-npcbeastmaster/Pet.cpp.beastmaster.patch
+# In order to revert the patch use this command:
+# patch -lR src/server/game/Entities/Pet/Pet.cpp <modules/mod-npcbeastmaster/Pet.cpp.beastmaster.patch
+# Please take into account that this patch changes the core functionality, so use at your own risk!)
 
 BeastMaster.HunterOnly = 0
 


### PR DESCRIPTION
PR https://github.com/azerothcore/azerothcore-wotlk/pull/857 was generally a bad idea. So I created an optional patch file to change a small part of the core functionality (Pet.cpp, function Guardian::InitStatsForLevel) in order to handle the beastmaster pets like hunter pets. The patch can be easily installed using the following command:
`patch -l src/server/game/Entities/Pet/Pet.cpp <modules/mod-npcbeastmaster/Pet.cpp.beastmaster.patch`
Revert the patch:
`patch -lR src/server/game/Entities/Pet/Pet.cpp <modules/mod-npcbeastmaster/Pet.cpp.beastmaster.patch`